### PR TITLE
Adding Diffprivlib, IBM's differential privacy library

### DIFF
--- a/tools/de-identification/Diffprivlib/README.md
+++ b/tools/de-identification/Diffprivlib/README.md
@@ -1,0 +1,15 @@
+# Diffprivlib
+
+**Primary Focus Area (select one):** De-identification
+
+**De-identification Keywords (select any relevant):** Differential Privacy, Machine Learning, Data Analytics
+
+**Brief Description:** Diffprivlib is a general-purpose Python library for experimenting with, and, building tools for, differential privacy. Diffprivlib includes a number of algorithms for machine learning and data analytics with differential privacy off-the-shelf in the familiar Scikit-learn and Numpy syntax.
+
+**Additional Notes:** [Introductory whitepaper](https://arxiv.org/abs/1907.02444)
+
+**GitHub User Serving as POC:** @naoise-h (naoise@ibm.com)
+
+**Affiliation/Organization(s) Contributing:** IBM Research
+
+**Tool Link:** https://github.com/IBM/differential-privacy-library

--- a/tools/de-identification/README.md
+++ b/tools/de-identification/README.md
@@ -28,6 +28,12 @@ Contributions are listed in alphabetical order.
 
 **[More Information](https://github.com/usnistgov/PrivacyEngCollabSpace/tree/master/tools/de-identification/Differentially-Private-Stochastic-Gradient-Descent-DP-SGD)** | **[Link to Tool](https://github.com/tensorflow/privacy)**
 
+## Diffprivlib
+
+**Keywords:** Differential Privacy, Machine Learning, Data Analytics
+
+**[More Information](https://github.com/usnistgov/PrivacyEngCollabSpace/tree/master/tools/de-identification/Diffprivlib)** | **[Link to Tool](https://github.com/IBM/differential-privacy-library)**
+
 ## Duet
 
 **Keywords:** Differential Privacy, Verification of Algorithms, Machine Learning
@@ -53,7 +59,7 @@ Contributions are listed in alphabetical order.
 
 ## Privacy Protection Application (PPA) 
 
-**Keywords:** K-Anonymity, Anonymization, Information Leakage, Algorithmic Fairness, Database Queries, Location Data         
+**Keywords:** K-Anonymity, Anonymization, Information Leakage, Algorithmic Fairness, Database Queries, Location Data
 
 **[More Information](https://github.com/usnistgov/PrivacyEngCollabSpace/tree/master/tools/de-identification/Privacy-Protection-Application-PPA)** | **[Link to Tool](https://github.com/usdot-its-jpo-data-portal/privacy-protection-application)**
 


### PR DESCRIPTION
**One sentence description of contribution:** Adding Diffprivlib as a de-identification tool.

**Additional notes:**