### PR TITLE
Add use case: Healthcare Patient Data Privacy Risk Assessment

### DIFF
--- a/use-cases/risk-assessment/Healthcare-Patient-Data-Privacy-Risk-Assessment/README.md
+++ b/use-cases/risk-assessment/Healthcare-Patient-Data-Privacy-Risk-Assessment/README.md
@@ -1,0 +1,86 @@
+# Healthcare Patient Data Privacy Risk Assessment
+
+**Name of Use Case:** Healthcare Patient Data Privacy Risk Assessment
+
+**Primary Focus Area (select one):** Privacy Risk Assessment
+
+**Brief Description:** This use case describes how a healthcare organization can conduct a privacy risk assessment for patient data processing activities, including EHR management, clinical research data sharing, and health information exchange (HIE) participation. It applies the NIST Privacy Risk Assessment Methodology (PRAM) to healthcare-specific data flows and maps findings to HIPAA Privacy Rule requirements and the NIST Privacy Framework.
+
+**Additional Notes:**
+- Aligns with NIST PRAM problematic data actions and the NIST Privacy Framework Core functions (Identify, Govern, Control, Communicate, Protect)
+- Addresses healthcare-specific risk factors: re-identification of patients with rare conditions, inference attacks on diagnosis codes, and risks from longitudinal health records
+- Can be adapted for health plans, clearinghouses, and business associates in addition to covered entities
+- Related resources: HHS Guidance on De-identification, NIST SP 800-188, OCR HIPAA Audit Protocol
+
+**GitHub User Serving as POC (or Email Address):** @pw0607
+
+**Affiliation/Organization(s) Contributing (if relevant):** Independent Researcher
+
+## For A Hosted Use Case
+
+**Context:**
+
+1. A healthcare covered entity (hospital, clinic, or health system) subject to HIPAA that processes Protected Health Information (PHI) for treatment, payment, and healthcare operations, and shares data with researchers, public health agencies, and health information exchanges.
+
+2. The organization's objectives include:
+   - Delivering high-quality patient care supported by data-driven clinical decision tools
+   - Participating in clinical research and public health surveillance
+   - Exchanging health information with other providers through regional HIEs
+   - Complying with HIPAA, state health privacy laws, and the NIST Privacy Framework
+
+3. Data subjects are patients of the healthcare organization, spanning all ages and demographics. The population includes vulnerable subgroups such as minors, individuals with mental health or substance use disorder diagnoses (subject to 42 CFR Part 2), and individuals with rare diseases who face heightened re-identification risk.
+
+4. The privacy goal is to systematically identify, assess, and mitigate privacy risks arising from the organization's data processing activities, ensuring that:
+   - Patient data is used only for authorized purposes
+   - Re-identification risk for de-identified datasets is quantified and kept below acceptable thresholds
+   - Data sharing with third parties is governed by appropriate agreements and technical safeguards
+   - Patients have meaningful transparency into how their data is used
+
+5. Negative outcomes if the privacy goal is not met:
+   - Unauthorized disclosure of sensitive diagnoses (e.g., HIV, mental health, genetic conditions) leading to stigma, discrimination, or personal harm
+   - HIPAA enforcement actions and civil monetary penalties (up to $1.5M per violation category annually)
+   - Loss of patient trust, reduced willingness to share health information, and downstream impact on care quality
+   - Breach notification obligations and associated reputational and financial costs
+   - Chilling effect on research participation if patients fear data misuse
+
+**Processing:**
+
+6. Data processing activities across the information lifecycle:
+   - **Collection:** PHI is collected during patient registration, clinical encounters, lab orders, imaging, pharmacy dispensing, and patient-reported outcomes. Data sources include EHR systems, patient portals, connected medical devices, and third-party labs.
+   - **Use:** PHI is used for treatment (clinical decision support, care coordination), payment (claims processing, eligibility verification), and operations (quality measurement, population health analytics).
+   - **Sharing:** De-identified or limited datasets are shared with academic researchers under data use agreements. PHI is exchanged with other providers via HIE networks. Aggregate data is reported to public health agencies and quality registries.
+   - **Storage:** PHI is stored in EHR databases, data warehouses, cloud-based analytics platforms, and backup systems. Retention periods follow state law and organizational policy (typically 7-10 years post last encounter).
+   - **Disposal:** Data is securely deleted or de-identified at end of retention period per NIST SP 800-88 media sanitization guidelines.
+
+7. Yes. The organization can provide detailed descriptions of each data processing activity, including data elements involved, systems used, access controls, and accuracy/completeness requirements for clinical and research use.
+
+8. The organization publishes aggregate quality metrics and population health statistics publicly. De-identified datasets may be released to approved researchers. The organization does not release identifiable patient data publicly.
+
+9. Current privacy protections include:
+   - HIPAA-compliant administrative, physical, and technical safeguards
+   - Role-based access controls and minimum necessary policies
+   - Encryption at rest and in transit for all PHI
+   - Business associate agreements with all third-party data processors
+   - Annual HIPAA risk assessments (security-focused) and workforce privacy training
+   - Patient rights processes (access, amendment, accounting of disclosures)
+   - IRB oversight for all research involving patient data
+
+10. Data:
+
+    a. Data includes structured clinical data (demographics, diagnoses, procedures, medications, lab results) in HL7 FHIR and relational database formats, unstructured clinical notes, and medical imaging metadata. The organization maintains records for approximately 500K-2M patients, with total data volumes of 1-50TB.
+
+    b. The organization is willing to share synthetic datasets derived from de-identified data with researchers for the purpose of developing and validating privacy risk assessment methodologies. Real data sharing requires IRB approval and a data use agreement.
+
+**Solutions (for use cases with implemented solutions):**
+
+11. Lessons learned:
+    - Applying the NIST PRAM to healthcare data flows revealed that the highest-risk activities were not the obvious ones (e.g., external research sharing) but rather internal analytics pipelines where access controls were broadly scoped and data minimization was not enforced.
+    - Mapping data flows to NIST Privacy Framework subcategories (particularly CT.DP-P for disassociated processing and CT.DM-P for data minimization) provided a structured way to identify gaps that HIPAA compliance alone did not surface.
+    - Quantifying re-identification risk using metrics like prosecutor and journalist risk models helped translate abstract privacy concerns into concrete, actionable thresholds for the de-identification team.
+    - Engaging clinicians early in the risk assessment process improved buy-in and surfaced data processing activities that IT and compliance teams were unaware of.
+
+12. Challenges and limitations:
+    - HIPAA risk assessments focus primarily on security (breach prevention) rather than privacy (appropriate use); integrating the NIST PRAM required organizational change management to broaden the scope.
+    - Quantifying privacy risk for unstructured clinical notes is significantly harder than for structured data; NLP-based approaches for PHI detection have non-trivial false negative rates.
+    - Balancing privacy risk reduction with clinical data utility is an ongoing negotiation; overly aggressive de-identification can render datasets unusable for certain research questions.
+    - State-level health privacy laws (e.g., stricter protections for mental health, substance use, reproductive health data) add complexity that a single risk assessment framework must accommodate.


### PR DESCRIPTION
**One sentence description of contribution:**
Adds a use case applying the NIST PRAM to healthcare patient data flows including EHR management, research data sharing, and health information exchange.

**Additional notes:**
Only the second contribution to the risk-assessment use cases directory.